### PR TITLE
ci: use client-id instead of deprecated app-id for release-please app token

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,7 +23,7 @@ jobs:
             - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
               id: app-token
               with:
-                  app-id: ${{ vars.RELEASE_PLEASE_APP_CLIENT_ID }}
+                  client-id: ${{ vars.RELEASE_PLEASE_APP_CLIENT_ID }}
                   private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
             - id: release
               uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0


### PR DESCRIPTION
## Summary

`actions/create-github-app-token` deprecated the `app-id` input in favor of `client-id`, which emitted a deprecation warning on every run of the Release Please workflow:

> Input 'app-id' has been deprecated with message: Use 'client-id' instead.

The existing variable `vars.RELEASE_PLEASE_APP_CLIENT_ID` already holds a client id, so this just renames the input key — no new variable/secret required.

## Changes
- `.github/workflows/release-please.yml`: `app-id` → `client-id`