### PR TITLE
chore: remove @lmoesle from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default owners — requested as reviewers on every PR, including Dependabot's
-* @emaarco @peterhnm @lmoesle
+* @emaarco @peterhnm


### PR DESCRIPTION
## Summary

Remove @lmoesle as a code owner so they are no longer automatically requested as a reviewer on every PR.

## Type of change

- [x] Tooling / CI

## Checklist

- [ ] `npm test` passes
- [ ] `npm run lint` passes
- [ ] `npm run typecheck` passes
- [ ] `npm run format:check` passes
- [ ] Rebuilt and committed `apps/camunda-modeler-i18n-plugin/dist/` (only if plugin source changed)
- [x] PR title is a changelog-worthy Conventional-Commit summary

## Linked issue

n/a